### PR TITLE
npm run firefox improved

### DIFF
--- a/manual_test.js
+++ b/manual_test.js
@@ -11,6 +11,9 @@
 console.log("Starting up firefox");
 const utils = require("./test/utils");
 const firefox = require("selenium-webdriver/firefox");
+const webdriver = require("selenium-webdriver");
+const Key = webdriver.Key;
+const By = webdriver.By;
 
 const Context = firefox.Context;
 
@@ -20,29 +23,21 @@ const Context = firefox.Context;
 
     console.log("Starting up firefox");
 
-    //* // add the share-button to the toolbar
-    //* await utils.addShareButton(driver);
-    //* // set the treatment
-    //* await driver.executeAsyncScript((typeArg, callback) => {
-    //*   Components.utils.import("resource://gre/modules/Preferences.jsm");
-    //*   if (typeArg !== null) {
-    //*     Preferences.set("extensions.sharebuttonstudy.treatment", typeArg);
-    //*   }
-    //*   callback();
-    //* }, "doorhangerAskToAdd");
-
     // install the addon
     await utils.installAddon(driver);
     console.log("Load temporary addon.");
 
 
-    // navigate to a regular page
-    //* driver.setContext(Context.CONTENT);
-    //* await driver.get("http://github.com/mozilla");
-    // driver.setContext(Context.CHROME);
+    // navigate to about:config and get study prefs
+    driver.setContext(Context.CONTENT);
+    await driver.get("about:config");
+    const aboutConfigTextbox = driver.findElement(By.id("textbox"));
+    const findStudyPrefs = "cfr";
+    await aboutConfigTextbox.sendKeys(findStudyPrefs);
+    await aboutConfigTextbox.sendKeys(Key.RETURN);
 
+    driver.setContext(Context.CHROME);
 
-    //* await utils.copyUrlBar(driver);
   } catch (e) {
     console.error(e); // eslint-disable-line no-console
   }

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,6 +26,8 @@ const FIREFOX_PREFERENCES = {
   // toolbox.
   "devtools.chrome.enabled": true,
   "devtools.debugger.remote-enabled": true,
+  "devtools.debugger.prompt-connection": false,
+  "general.warnOnAboutConfig": false,
 };
 
 // useful if we need to test on a specific version of Firefox


### PR DESCRIPTION
npm run firefox now opens 'about:config' and pulls up the study-specific prefs for CFR

![more-test-automation](https://user-images.githubusercontent.com/17437436/31689470-5f32f89e-b344-11e7-97f1-ddd943c6a03d.gif)
